### PR TITLE
Use non-posix way to split command string.

### DIFF
--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -494,7 +494,8 @@ class Loader(object):
                 print("... executing command param [%s]" % command)
             import subprocess, shlex #shlex rocks
             try:
-                p = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE)
+                os_posix = os.name == "posix"
+                p = subprocess.Popen(shlex.split(command, posix=os_posix), stdout=subprocess.PIPE)
                 c_value = p.communicate()[0]
                 if not isinstance(c_value, str):
                     c_value = c_value.decode('utf-8')


### PR DESCRIPTION
When I am using the roslaunch, the command string in the launch XML won't be split after shlex.split, instead it pass the string as a whole to Popen and it causes problems. Say, when the command string is "xacro --inorder xyz.xacro", then it will try to CreateProcess for the whole string, instead of "xacro.exe" and then "--inorder xyz.xacro" goes as arguments.

Use posix=False for shlex.split will fix the issue.