### PR TITLE
normalize the string to utf-8 before passing to environment block.

### DIFF
--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -211,7 +211,7 @@ def setup_env(node, machine, master_uri, env=None):
         if ns:
             d[rosgraph.ROS_NAMESPACE] = ns 
         for name, value in node.env_args:
-            d[name] = value
+            d[str(name)] = str(value)
 
     return d
 


### PR DESCRIPTION
xmlloader is using unicode process the XML text so for example, when a launch xml is using $env or $optenv, then xmlloader returns the env_args as unicode string instead of utf-8 ones when passing to the environment block. In this case, you will see an exceptions from Popen with "environment can only contain strings".

The fix is to normalize it before passing into the env block.