### PR TITLE
Use shell feature for roslaunch command

### DIFF
--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -501,7 +501,9 @@ class Loader(object):
             import subprocess, shlex #shlex rocks
             try:
                 os_posix = os.name == "posix"
-                p = subprocess.Popen(shlex.split(command, posix=os_posix), stdout=subprocess.PIPE, shell=not os_posix)
+                if os_posix:
+                    command = shlex.split(command)
+                p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=not os_posix)
                 c_value = p.communicate()[0]
                 if not isinstance(c_value, str):
                     c_value = c_value.decode('utf-8')

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -501,7 +501,7 @@ class Loader(object):
             import subprocess, shlex #shlex rocks
             try:
                 os_posix = os.name == "posix"
-                p = subprocess.Popen(shlex.split(command, posix=os_posix), stdout=subprocess.PIPE)
+                p = subprocess.Popen(shlex.split(command, posix=os_posix), stdout=subprocess.PIPE, shell=not os_posix)
                 c_value = p.communicate()[0]
                 if not isinstance(c_value, str):
                     c_value = c_value.decode('utf-8')


### PR DESCRIPTION
Use shell feature for roslaunch command, so we don't need to specify the exact Python wrapper file name (for example, xacro.exe) in the launch XML. Therefore it reduces the needs to touch .launch file.