### PR TITLE
Move the winsock2.h header into cpp file

### DIFF
--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServer.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServer.h
@@ -15,9 +15,7 @@
 # include <map>
 # include <string>
 # include <vector>
-# if defined(_WINDOWS)
-#  include <winsock2.h>
-# else
+# ifndef _WINDOWS
 #  include <poll.h>
 # endif
 #endif
@@ -127,8 +125,10 @@ namespace XmlRpc {
 
     // Minimum number of free file descriptors before rejecting clients.
     static const int FREE_FD_BUFFER;
+#ifndef _WINDOWS
     // List of all file descriptors, used for counting open files.
     std::vector<struct pollfd> pollfds;
+#endif
   };
 } // namespace XmlRpc
 

--- a/utilities/xmlrpcpp/src/XmlRpcServer.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServer.cpp
@@ -13,6 +13,8 @@
 #include <string.h>
 #if !defined(_WINDOWS)
 # include <sys/resource.h>
+#else
+# include <winsock2.h>
 #endif
 
 using namespace XmlRpc;


### PR DESCRIPTION
This is one of the PRs to remove Windows.h from ROS headers, and in turn we reduce the Windows namespace conflicts problems for many downstream packages.