### PR TITLE
fix rosgraph\test_roslogging issues

### DIFF
--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -62,6 +62,7 @@ class RospyLogger(logging.getLoggerClass()):
         else:
             return file_name, lineno, func_name
 
+        file_name = os.path.normcase(file_name)
         while hasattr(f, "f_code"):
             if f.f_back is None:
                 break

--- a/tools/rosgraph/test/test_roslogging.py
+++ b/tools/rosgraph/test/test_roslogging.py
@@ -92,6 +92,9 @@ try:
         base, ext = os.path.splitext(this_file)
         if ext == '.pyc':
             this_file = base + '.py'
+        
+        if sys.platform in ['win32']:
+            this_file = this_file.replace('\\', r'\\')
 
         for i, loc in enumerate(['module', 'function', 'method']):
             if loc == 'module':


### PR DESCRIPTION
test_roslogging test cases were failing due to 2 reasons:
* `file_name` returned from `Logger.findCaller()` were directly compared with `os.path.normcase(f.f_code.co_filename)` (where `f` is a frame object) without being normalized with `os.path.normcase`;
* `this_file` used as regular expression in `assert_regexp_matches` is not escaped for file paths in Windows (`\` as delimiter needs to be escaped)