### PR TITLE
skip roslaunch testcases for CAT command in Windows

### DIFF
--- a/test/test_roslaunch/test/params_basic.py
+++ b/test/test_roslaunch/test/params_basic.py
@@ -108,9 +108,13 @@ class TestParamsBasic(unittest.TestCase):
         with open(os.path.join(dir, 'resources', 'example.launch'), 'r') as f:
             text_data = f.read()
         binary_data = Binary(text_data)
-        self.assertEquals(get_param("commandoutput"), text_data)
+
+        # test 'command' attribute
+        if os.name != 'nt' : # skip testcase for `cat` command in Windows
+            self.assertEquals(get_param("commandoutput"), text_data)
+        # test 'textfile' attribute
         self.assertEquals(get_param("textfile"), text_data)
-        ## test 'binfile' attribute
+        # test 'binfile' attribute
         bindata = get_param("binaryfile")
         self.assertTrue(isinstance(bindata, Binary))
         self.assertEquals(bindata.data, binary_data)

--- a/test/test_roslaunch/test/params_basic.test
+++ b/test/test_roslaunch/test/params_basic.test
@@ -60,7 +60,7 @@
   
   <param name="textfile" textfile="$(find roslaunch)/resources/example.launch" />
   <param name="binaryfile" binfile="$(find roslaunch)/resources/example.launch" />
-  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" />
+  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" unless="$(eval optenv('OS', 'unknown').lower().startswith('windows'))" />
 
   <test test-name="params_basic" pkg="test_roslaunch" type="params_basic.py" />
 </launch>

--- a/tools/roslaunch/resources/example.launch
+++ b/tools/roslaunch/resources/example.launch
@@ -30,7 +30,7 @@
   <!-- upload the contents of a file as base64 binary as a param -->
   <param name="binaryfile" binfile="$(find roslaunch)/resources/example.launch" />
   <!-- upload the output of a command as a param. -->
-  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" />
+  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" unless="$(eval optenv('OS', 'unknown').lower().startswith('windows'))" />
   
   <!-- Group a collection of tags. ns attribute is optional -->
   <group ns="wg"> 

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -220,13 +220,9 @@ class TestXmlLoader(unittest.TestCase):
         p = [p for p in mock.params if p.key == '/binaryfile'][0]
         self.assertEquals(Binary(contents), p.value, 1)
 
-        f = open(os.path.join(get_example_path(), 'example.launch'))
-        try:
-            contents = f.read()
-        finally:
-            f.close()
-        p = [p for p in mock.params if p.key == '/commandoutput'][0]
-        self.assertEquals(contents, p.value, 1)
+        if os.name != 'nt': # skip testcase for `cat` command in Windows
+            p = [p for p in mock.params if p.key == '/commandoutput'][0]
+            self.assertEquals(contents, p.value, 1)
         
         
     def test_rosparam_valid(self):

--- a/tools/roslaunch/test/xml/test-params-valid.xml
+++ b/tools/roslaunch/test/xml/test-params-valid.xml
@@ -33,13 +33,13 @@
   <!-- upload the contents of a file as base64 binary as a param -->
   <param name="binaryfile" binfile="$(find roslaunch)/resources/example.launch" />
   <!-- upload the output of a command as a param. -->
-  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" />
+  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" unless="$(eval optenv('OS', 'unknown').lower().startswith('windows'))" />
 
   <!-- upload the output of a command as a param as types. -->
   <param name="commandoutputinteger" type="int" command="echo 0" />
   <param name="commandoutputdouble" type="double" command="echo 10" />
   <param name="commandoutputbool" type="bool" command="echo true" />
-  <param name="commandoutputyaml" type="yaml" command="cat &quot;$(find roslaunch)/test/params.yaml&quot;" />
+  <param name="commandoutputyaml" type="yaml" command="cat &quot;$(find roslaunch)/test/params.yaml&quot;" unless="$(eval optenv('OS', 'unknown').lower().startswith('windows'))" />
 
 
   <!-- test that we can override params -->


### PR DESCRIPTION
* when executing on Windows, skip test cases testing the Linux-specific `CAT` command
* add `unless="$(eval optenv('OS', 'unknown').lower().startswith('windows'))"` attribute in launch file to prevent the `'cat' is not recognized as an internal or external command, operable program or batch file.` error