### PR TITLE
escape os.sep for regular expression comparison

### DIFF
--- a/test/test_rospy/test/unit/test_rospy_core.py
+++ b/test/test_rospy/test/unit/test_rospy_core.py
@@ -116,6 +116,8 @@ class TestRospyCore(unittest.TestCase):
             base, ext = os.path.splitext(this_file)
             if ext == '.pyc':
                 this_file = base + '.py'
+            if os.sep == '\\':
+                this_file = this_file.replace(os.sep, r'\\')
 
             try:
                 # hack to replace the stream handler with a debug version

--- a/tools/rosgraph/test/test_roslogging.py
+++ b/tools/rosgraph/test/test_roslogging.py
@@ -93,8 +93,8 @@ try:
         if ext == '.pyc':
             this_file = base + '.py'
         
-        if sys.platform in ['win32']:
-            this_file = this_file.replace('\\', r'\\')
+        if os.sep == '\\':
+            this_file = this_file.replace(os.sep, r'\\')
 
         for i, loc in enumerate(['module', 'function', 'method']):
             if loc == 'module':


### PR DESCRIPTION
`os.sep` is `\\` on Windows, and would need to be escaped to `\\\\` for regular expression comparison