### PR TITLE
add python prefix for python script when there is no .py extension

### DIFF
--- a/tools/roslaunch/src/roslaunch/node_args.py
+++ b/tools/roslaunch/src/roslaunch/node_args.py
@@ -262,7 +262,11 @@ def create_local_process_args(node, machine, env=None):
     if not cmd:
         raise NodeParamsException("Cannot locate node of type [%s] in package [%s]"%(node.type, node.package))
     cmd = [cmd]
-    if sys.platform in ['win32']:
-        if os.path.splitext(cmd[0])[1] == '.py':
+
+    # add python prefix for python script in Windows environment
+    if os.name == 'nt':
+        _, ext = os.path.splitext(cmd[0])
+        # ROS nodes as python scripts tend to omit .py extension, still try launching with python
+        if ext.lower() in ['.py', '']:
             cmd = ['python'] + cmd
     return _launch_prefix_args(node) + cmd + args


### PR DESCRIPTION
python scripts tend to omit `.py` extension on Linux environment, making them not executable on Windows. for this kind of scenario, when a node is returned without extension, add `python` prefix to launch the node as python script