### PR TITLE
Fixup single quotes usage in roslaunch command.

### DIFF
--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -500,13 +500,13 @@ class Loader(object):
                     # 1. search for a wrapper executable (of the same name) under the same directory with stat.S_IXUSR flag
                     # 2. if no wrapper is present, prepend command with 'python' executable
                     def split_with_single_quote_enclosed_fixup(command):
-                        in_command = shlex.split(command, posix=False)  # use non-posix method on Windows
+                        tokens = shlex.split(command, posix=False)  # use non-posix method on Windows
                         if not ("'" in command):
-                            return in_command
+                            return tokens
                         new_command = []
-                        for token in in_command:
+                        for token in tokens:
                             if token.startswith("'") and token.endswith("'"):
-                                new_command.append("{}".format(token[1:-1]))
+                                new_command.append(token[1:-1])
                             else:
                                 new_command.append(token)
                         return new_command

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -499,6 +499,17 @@ class Loader(object):
                     # special handle the use of Python scripts in Windows environment:
                     # 1. search for a wrapper executable (of the same name) under the same directory with stat.S_IXUSR flag
                     # 2. if no wrapper is present, prepend command with 'python' executable
+                    def split_with_single_quote_enclosed_fixup(command):
+                        in_command = shlex.split(command, posix=False)  # use non-posix method on Windows
+                        if not ("'" in command):
+                            return in_command
+                        new_command = []
+                        for token in in_command:
+                            if token.startswith("'") and token.endswith("'"):
+                                new_command.append("{}".format(token[1:-1]))
+                            else:
+                                new_command.append(token)
+                        return new_command
 
                     cl = shlex.split(command, posix=False)  # use non-posix method on Windows
                     if os.path.isabs(cl[0]):
@@ -526,6 +537,7 @@ class Loader(object):
                                             executable_command = ' '.join([sys.executable, f])
                             if executable_command:
                                 command = command.replace(cl[0], executable_command, 1)
+                    command = split_with_single_quote_enclosed_fixup(command)
                 p = subprocess.Popen(command, stdout=subprocess.PIPE)
                 c_value = p.communicate()[0]
                 if not isinstance(c_value, str):


### PR DESCRIPTION
In ROS, it is very common to see the following examples in `roslaunch` files:

```
<param name="robot_description" command="$(find xacro)/xacro.py '$(find xyz)/urdf/abc.xacro'" />
```

On Linux shell, single quotes can be used to encapsulate a string argument, and the quotes are not passed to the application. However, on Windows shell, the single quotes are not reserved for this purpose and it will be passed down to the application, which subsequently causes problems (like `xacro` tries to open a file path with quotes).

Before this fix, we advise ROS developer to replace single quotes with double quotes in `roslunach` files. However, this approach is less scalable. With this fix, they should simply remain as is and `roslaunch` takes care of this difference. (See https://github.com/ros-planning/panda_moveit_config/pull/32)