### PR TITLE
revert back to localhost.

### DIFF
--- a/tools/roslaunch/env-hooks/10.roslaunch.bat
+++ b/tools/roslaunch/env-hooks/10.roslaunch.bat
@@ -1,15 +1,5 @@
 REM roslaunch/env-hooks/10.roslaunch.bat
 
-:: workaround Python 2 xmlrpc performance issue
-:: https://stackoverflow.com/questions/2617615/slow-python-http-server-on-localhost
-:: use IP address instead to avoid unnecessary DNS lookups.
 if "%ROS_MASTER_URI%" == "" (
-  set ROS_MASTER_URI=http://127.0.0.1:11311
-)
-
-:: it is discourage to set ROS_IP and ROS_HOSTNAME at the same time.
-if "%ROS_IP%" == "" (
-  if "%ROS_HOSTNAME%" == "" (
-    set ROS_IP=127.0.0.1
-  )
+  set ROS_MASTER_URI=http://localhost:11311
 )


### PR DESCRIPTION
ROS prevents remote connections when using 127.0.0.1. Microsoft originally switched from localhost to 127.0.0.1 for performance reasons. localhost resolution is now a fast path no longer requiring this workaround.